### PR TITLE
Add virtual network name and resource group to artifacts

### DIFF
--- a/src/_artifacts.tf
+++ b/src/_artifacts.tf
@@ -9,11 +9,13 @@ resource "massdriver_artifact" "vnet" {
           id                = azurerm_virtual_network.main.id
           cidr              = local.cidr
           default_subnet_id = azurerm_subnet.main.id
+          name = azurerm_virtual_network.main.name
         }
       }
       specs = {
         azure = {
           region = azurerm_virtual_network.main.location
+          resource_group_name = azurerm_virtual_network.main.resource_group_name
         }
       }
     }


### PR DESCRIPTION
Adding this in so that I can make subnets in separate bundles -- they require virtual network name and rg